### PR TITLE
Allow user to reset token

### DIFF
--- a/client/static/js/profile.js
+++ b/client/static/js/profile.js
@@ -10,6 +10,15 @@ function load_token()
     })
 }
 
+function reset_token()
+{
+    fetch("/api/token/reset")
+    .then(res => res.json())
+    .then(json => {
+        $("#token").val(json.token);
+    })
+}
+
 function add_score(score, chart_hashmap)
 {
     var row = $(`<tr></tr>`);

--- a/client/views/pages/profile.ejs
+++ b/client/views/pages/profile.ejs
@@ -52,7 +52,7 @@
 						<div class="tab-pane fade" id="settings-tab" role="tabpanel">
 	                        <div class="row justify-content-center" style="padding: 10px;">
 	                            <div class="col-12 text-center">
-	                                <button type="button" class="btn btn-highlight" data-toggle="modal" data-target="#view-token-modal">View IR token</button>
+	                                <button type="button" class="btn btn-highlight" data-toggle="modal" data-target="#view-token-modal">Manage IR token</button>
 	                            </div>
 	                        </div>
 	                    </div>
@@ -65,7 +65,7 @@
 			<div class="modal-dialog" role="document">
 			    <div class="modal-content">
 			    	<div class="modal-header">
-		        		<h5 class="modal-title">View IR token</h5>
+		        		<h5 class="modal-title">Manage IR token</h5>
 		        		<button type="button" class="close" data-dismiss="modal" aria-label="Close">
 		          			<span aria-hidden="true">&times;</span>
 		        		</button>
@@ -73,15 +73,15 @@
 					<div class="modal-body">
 						<form>
           					<div class="form-group">
-            					<label class="col-form-label" style="color: red;">Note: your token is sensitive and should not be shown to anyone else. If you understand this, press the button below to view it.</label>
+            					<label class="col-form-label" style="color: red;">Note: your token is sensitive and should not be shown to anyone else.</label>
             					<input type="text" class="form-control" id="token" readonly="">
-
           					</div>
-                            <div class="form-group">
-                                        <button type="button" class="btn btn-highlight" onclick="load_token()">I understand, show me the token</button>
-							</div>
         				</form>
 		      		</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-highlight mr-auto" onclick="load_token()">Show my token</button>
+						<button type="button" class="btn btn-highlight" onclick="reset_token()">Reset my token</button>
+					</div>
 		    	</div>
 		  	</div>
 		</div>

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -12,6 +12,7 @@ const router = express.Router();
 router.get("/charts",                   WebAPIService.QueryCharts);
 router.get("/charts/:chartHash/scores", WebAPIService.ChartScores);
 router.get("/players/:username/scores", WebAPIService.PlayerScores);
-router.get("/token",    WebLoggedIn,    WebAPIService.GetToken);
+router.get("/token",       WebLoggedIn, WebAPIService.GetToken);
+router.get("/token/reset", WebLoggedIn, WebAPIService.ResetToken);
 
 module.exports = router;


### PR DESCRIPTION
Closes #5.

'View IR token' button on profile page is now a 'Manage IR token' button, and the modal has options to both view and reset token.

(Previous PR closed because of some nightmare git history I accidentally created)